### PR TITLE
Add sort property for the zfs list command

### DIFF
--- a/lib/zfs.js
+++ b/lib/zfs.js
@@ -129,6 +129,11 @@ function list(opts, cb) {
         params.push(opts.type);
     }
 
+    if (opts && opts.sort) {
+        params.push('-s');
+        params.push(opts.sort);
+    }
+
     zfs(params, function (err, stdout) {
         if (cb && typeof cb === 'function') {
             if (err) {


### PR DESCRIPTION
It would be nice to have the property to sort the output of `zfs list`. 
