### PR TITLE
Add support for creating ZFS zvol

### DIFF
--- a/lib/zfs.js
+++ b/lib/zfs.js
@@ -177,7 +177,9 @@ function create(opts, cb) {
     "use strict";
 
     var params = [ 'create' ];
-
+    if (opts.size) {
+      params.push('-V', parseNumber(opts.size));
+    }
     params.push(opts.name);
 
     zfs(params, cb);


### PR DESCRIPTION
When a size option is passed to create(), create a ZFS volume (zvol) instead.

Comments and feedback more than welcome.
