### PR TITLE
Return error when trying to get properties of inexistent dataset

### DIFF
--- a/lib/zfs.js
+++ b/lib/zfs.js
@@ -158,6 +158,7 @@ function get(opts, cb) {
 
     zfs(params, function (err, stdout) {
         if (cb && typeof cb === 'function') {
+            if (err) return cb(err);
             var lines = compact(stdout.split('\n'));
             var list = lines.map(function (x) { return new Property(x); });
             cb(err, list);


### PR DESCRIPTION
Previously it would throw an exception calling split on undefined.
