### PR TITLE
Fix for retrieving empty property value on FreeBSD

### DIFF
--- a/lib/zfs.js
+++ b/lib/zfs.js
@@ -97,7 +97,7 @@ function Property(info) {
 
     var obj = Object.create({});
     if (typeof info === 'string') {
-        info = info.split(/\s+/, 4);
+        info = info.split(/\t/, 4);
     }
 
     if (info.length !== 4) {

--- a/test/zfs
+++ b/test/zfs
@@ -2,28 +2,28 @@
 
 function listFs {
 cat <<EOD
-zones   947G    880G    321K    /zones
-zones/37a67136-6cdf-4f65-add2-85e4fce60d63      664M    9.35G   664M    /zones/37a67136-6cdf-4f65-add2-85e4fce60d63
-zones/37a67136-6cdf-4f65-add2-85e4fce60d63-disk0        1.40G   880G    1.04G   -
-zones/37a67136-6cdf-4f65-add2-85e4fce60d63/cores        31K     2.25G   31K     /zones/37a67136-6cdf-4f65-add2-85e4fce60d63/cores
-zones/39a4f744-85cf-416c-ad37-1b933f9e7b13      152K    10.0G   122K    /zones/39a4f744-85cf-416c-ad37-1b933f9e7b13
+zones	947G	880G	321K	/zones
+zones/37a67136-6cdf-4f65-add2-85e4fce60d63	664M	9.35G	664M	/zones/37a67136-6cdf-4f65-add2-85e4fce60d63
+zones/37a67136-6cdf-4f65-add2-85e4fce60d63-disk0	1.40G	880G	1.04G	-
+zones/37a67136-6cdf-4f65-add2-85e4fce60d63/cores	31K	2.25G	31K	/zones/37a67136-6cdf-4f65-add2-85e4fce60d63/cores
+zones/39a4f744-85cf-416c-ad37-1b933f9e7b13	152K	10.0G	122K	/zones/39a4f744-85cf-416c-ad37-1b933f9e7b13
 EOD
 }
 
 function listSnaps {
 cat << EOD
-zones/var@daily-20120516T043000Z        134K    -       2.69M   -
-zones/var@hourly-20120516T160000Z       38.5K   -       2.70M   -
-zones/var@hourly-20120516T170000Z       38.5K   -       2.70M   -
+zones/var@daily-20120516T043000Z	134K	-	2.69M	-
+zones/var@hourly-20120516T160000Z	38.5K	-	2.70M -
+zones/var@hourly-20120516T170000Z	38.5K	-	2.70M -
 EOD
 }
 
 function getAllProps {
 cat <<EOD
-zones   compression     on      local
-zones/f78f9208-9c26-47f7-9e03-881a96d17c04      compression     on      inherited from zones
-zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data compression     on      inherited from zones
-zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data@daily-20120430  compression     -       -
+zones	compression	on	local
+zones/f78f9208-9c26-47f7-9e03-881a96d17c04	compression	on	inherited from zones
+zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data	compression	on	inherited from zones
+zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data@daily-20120430	compression	-	-
 EOD
 }
 

--- a/test/zfs.js
+++ b/test/zfs.js
@@ -79,12 +79,12 @@ describe('zfs', function () {
                 name: 'zones/f78f9208-9c26-47f7-9e03-881a96d17c04',
                 property: 'compression',
                 value: 'on',
-                source: 'inherited'
+                source: 'inherited from zones'
             }, {
                 name: 'zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data',
                 property: 'compression',
                 value: 'on',
-                source: 'inherited'
+                source: 'inherited from zones'
             }, {
                 name: 'zones/f78f9208-9c26-47f7-9e03-881a96d17c04/data@daily-20120430',
                 property: 'compression',


### PR DESCRIPTION
On FreeBSD "zfs get" can sometime return empty value as empty string
(notably the "mlslabel" property) instead of returning "none". We're
already using -H option to "zfs get" which produce tab separated
output. Update the regexp that match "zfs get" lines to be separated
by tab instead of spaces.