### PR TITLE
Look for 'compact' in 'utils'

### DIFF
--- a/lib/zfs.js
+++ b/lib/zfs.js
@@ -9,7 +9,7 @@ function zfs(args, callback) {
     cp.execFile(zfsBin, args, {maxBuffer: 8000000}, function (err, stdout, stderr) {
         if (callback && typeof callback === 'function') {
             if (err) {
-                err.message = compact(err.message.split('\n')).join('; ').trim();
+                err.message = util.compact(err.message.split('\n')).join('; ').trim();
                 callback(err);
             } else {
                 callback(null, stdout);


### PR DESCRIPTION
Looks like an instance of changing `compact` to `utils.compact` was missed in #16 